### PR TITLE
Humanize incorrectly lowercases first letter of surname

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -26,7 +26,7 @@
               </svg> </span>
             <span class="meta-text">
               By {{ range .Params.Author }}
-              <a href="{{ `author/` | relLangURL }}{{ . | urlize | lower }}">{{ . | humanize }}</a>
+              <a href="{{ `author/` | relLangURL }}{{ . | urlize | lower }}">{{ . }}</a>
               {{ end }} </span>
           </li>
           <li class="post-date meta-wrapper">


### PR DESCRIPTION
When adding the author's surname, humanize incorrectly lowercases it.
i.e.
"Daniel Sada" becomes "Daniel sada"