### PR TITLE
Changes in date format

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -36,7 +36,7 @@
               <figure class="wp-block-image alignfull size-full"><img src="{{ .Params.Image |absURL }}"
                   alt="{{.Title }}" class="wp-image-37" /></figure>
               <h3>{{ .Title }}</h3>
-              <p>{{ .PublishDate.Format "January 06, 2006"}}</p>
+              <p>{{ .PublishDate.Format "January 6, 2006"}}</p>
               <div class="wp-block-button is-style-outline"><a class="wp-block-button__link"
                   href="{{ .Permalink }}">Read More</a></div>
             </div>


### PR DESCRIPTION
Generates the wrong date

when I was checking site this 06 generates format like 
month name 20, year for all sites.

when removed 0 this is work fine.

 this issue in old format, please check this for blog listing page that i have not mentioned here.

thank you in advance.