### PR TITLE
fix: theme name in exampleSite's config.toml

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,7 +1,7 @@
 ######################## default configuration ####################
 baseURL = "https://examplesite.com"
 title = "Twenty Twenty Hugo"
-theme = "twentytwenty"
+theme = "twenty-twenty-hugo"
 languageName = "En"
 languageCode = "en-us"
 # post pagination


### PR DESCRIPTION
Theme setting in config was inconsistent with the theme's default folder name.