### PR TITLE
Typo fix

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -11,7 +11,7 @@ summaryLength = "10"
 # disqus short name
 disqusShortname = "" # get your shortname form here : https://disqus.com
 # disable language
-disableLanguages = [] # desable language from here
+disableLanguages = [] # disable language from here
 # google analytics
 googleAnalytics = "" # example : UA-123-45
 


### PR DESCRIPTION
This fixes a small typo in the example ```config.toml``` file.