### PR TITLE
header: Allow to translate menu and "Close menu"

### DIFF
--- a/exampleSite/i18n/en.yaml
+++ b/exampleSite/i18n/en.yaml
@@ -9,3 +9,6 @@ hours: Hours
 to_the_top: To the top
 not_found: 404 Page Not Found!
 back_home: Back To Home
+close_menu: Close Menu
+Search: Search
+Menu: Menu

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -11,7 +11,7 @@
               <path
                 d="M38.710696,48.0601792 L43,52.3494831 L41.3494831,54 L37.0601792,49.710696 C35.2632422,51.1481185 32.9839107,52.0076499 30.5038249,52.0076499 C24.7027226,52.0076499 20,47.3049272 20,41.5038249 C20,35.7027226 24.7027226,31 30.5038249,31 C36.3049272,31 41.0076499,35.7027226 41.0076499,41.5038249 C41.0076499,43.9839107 40.1481185,46.2632422 38.710696,48.0601792 Z M36.3875844,47.1716785 C37.8030221,45.7026647 38.6734666,43.7048964 38.6734666,41.5038249 C38.6734666,36.9918565 35.0157934,33.3341833 30.5038249,33.3341833 C25.9918565,33.3341833 22.3341833,36.9918565 22.3341833,41.5038249 C22.3341833,46.0157934 25.9918565,49.6734666 30.5038249,49.6734666 C32.7048964,49.6734666 34.7026647,48.8030221 36.1716785,47.3875844 C36.2023931,47.347638 36.2360451,47.3092237 36.2726343,47.2726343 C36.3092237,47.2360451 36.347638,47.2023931 36.3875844,47.1716785 Z"
                 transform="translate(-20 -31)" /></svg> </span>
-          <span class="toggle-text">Search</span>
+          <span class="toggle-text">{{ T "Search" }}</span>
         </span>
       </button><!-- .search-toggle -->
       <div class="header-titles">
@@ -27,7 +27,7 @@
               <path fill-rule="evenodd"
                 d="M332.5,45 C330.567003,45 329,43.4329966 329,41.5 C329,39.5670034 330.567003,38 332.5,38 C334.432997,38 336,39.5670034 336,41.5 C336,43.4329966 334.432997,45 332.5,45 Z M342,45 C340.067003,45 338.5,43.4329966 338.5,41.5 C338.5,39.5670034 340.067003,38 342,38 C343.932997,38 345.5,39.5670034 345.5,41.5 C345.5,43.4329966 343.932997,45 342,45 Z M351.5,45 C349.567003,45 348,43.4329966 348,41.5 C348,39.5670034 349.567003,38 351.5,38 C353.432997,38 355,39.5670034 355,41.5 C355,43.4329966 353.432997,45 351.5,45 Z"
                 transform="translate(-329 -38)" /></svg> </span>
-          <span class="toggle-text">Menu</span>
+          <span class="toggle-text">{{ T "Menu" }}</span>
         </span>
       </button><!-- .nav-toggle -->
 
@@ -37,7 +37,7 @@
       <nav class="primary-menu-wrapper" aria-label="Horizontal" role="navigation">
         <ul class="primary-menu reset-list-style">
           {{ range .Site.Menus.desktop }}
-          <li class="menu-item"><a href="{{ .URL | absURL }}" aria-current="page">{{ .Name }}</a></li>
+	  <li class="menu-item"><a href="{{ .URL | absLangURL }}" aria-current="page">{{ T .Identifier | default .Name }}</a></li>
           {{ end }}
         </ul>
       </nav><!-- .primary-menu-wrapper -->
@@ -47,7 +47,7 @@
           <button class="toggle nav-toggle desktop-nav-toggle" data-toggle-target=".menu-modal"
             data-toggle-body-class="showing-menu-modal" aria-expanded="false" data-set-focus=".close-nav-toggle">
             <span class="toggle-inner">
-              <span class="toggle-text">Menu</span>
+              <span class="toggle-text">{{ T "Menu" }}</span>
               <span class="toggle-icon">
                 <svg class="svg-icon" aria-hidden="true" role="img" focusable="false" xmlns="http://www.w3.org/2000/svg"
                   width="26" height="7" viewbox="0 0 26 7">
@@ -67,7 +67,7 @@
                 width="23" height="23" viewbox="0 0 23 23">
                 <path
                   d="M38.710696,48.0601792 L43,52.3494831 L41.3494831,54 L37.0601792,49.710696 C35.2632422,51.1481185 32.9839107,52.0076499 30.5038249,52.0076499 C24.7027226,52.0076499 20,47.3049272 20,41.5038249 C20,35.7027226 24.7027226,31 30.5038249,31 C36.3049272,31 41.0076499,35.7027226 41.0076499,41.5038249 C41.0076499,43.9839107 40.1481185,46.2632422 38.710696,48.0601792 Z M36.3875844,47.1716785 C37.8030221,45.7026647 38.6734666,43.7048964 38.6734666,41.5038249 C38.6734666,36.9918565 35.0157934,33.3341833 30.5038249,33.3341833 C25.9918565,33.3341833 22.3341833,36.9918565 22.3341833,41.5038249 C22.3341833,46.0157934 25.9918565,49.6734666 30.5038249,49.6734666 C32.7048964,49.6734666 34.7026647,48.8030221 36.1716785,47.3875844 C36.2023931,47.347638 36.2360451,47.3092237 36.2726343,47.2726343 C36.3092237,47.2360451 36.347638,47.2023931 36.3875844,47.1716785 Z"
-                  transform="translate(-20 -31)" /></svg> <span class="toggle-text">Search</span>
+                  transform="translate(-20 -31)" /></svg> <span class="toggle-text">{{ T "Search" }}</span>
             </span>
           </button><!-- .search-toggle -->
         </div>
@@ -108,7 +108,7 @@
       <div class="menu-top">
         <button class="toggle close-nav-toggle fill-children-current-color" data-toggle-target=".menu-modal"
           data-toggle-body-class="showing-menu-modal" aria-expanded="false" data-set-focus=".menu-modal">
-          <span class="toggle-text">Close Menu</span>
+          <span class="toggle-text">{{T "close_menu"}}</span>
           <svg class="svg-icon" aria-hidden="true" role="img" focusable="false" xmlns="http://www.w3.org/2000/svg"
             width="16" height="16" viewbox="0 0 16 16">
             <polygon fill="" fill-rule="evenodd"
@@ -118,7 +118,7 @@
           <ul class="modal-menu reset-list-style">
             {{ range .Site.Menus.main }}
             <li class="menu-item menu-item-type-custom menu-item-object-custom">
-              <div class="ancestor-wrapper"><a href="{{ .URL | absURL }}" aria-current="page">{{ .Name }}</a></div>
+              <div class="ancestor-wrapper"><a href="{{ .URL | absLangURL }}" aria-current="page">{{ T .Identifier | default .Name }}</a></div>
             </li>
             {{ end }}
           </ul>
@@ -127,7 +127,7 @@
           <ul class="modal-menu reset-list-style">
             {{ range .Site.Menus.main }}
             <li class="menu-item menu-item-type-custom menu-item-object-custom">
-              <div class="ancestor-wrapper"><a href="{{ .URL | absURL }}" aria-current="page">{{ .Name }}</a></div>
+              <div class="ancestor-wrapper"><a href="{{ .URL | absLangURL }}" aria-current="page">{{ T .Identifier | default .Name }}</a></div>
             </li>
             {{ end }}
           </ul>


### PR DESCRIPTION
It's currently not possible to translate these without overriding the header. This looks like an oversight as translating other bits works just fine.